### PR TITLE
Fix missing log in explanation of popularity

### DIFF
--- a/app/suggestions2/app/naive_bayes/matrix.py
+++ b/app/suggestions2/app/naive_bayes/matrix.py
@@ -127,17 +127,17 @@ def compute_explanation_matrix(matrix: pd.DataFrame) -> Tuple[pd.DataFrame, pd.S
     """
     Computes the "explanation scores" matrix of the given naive bayes matrix.
 
-    This matrix contains the log conditional probabilities of the naive bayes matrix,
+    This matrix contains the log2 conditional probabilities of the naive bayes matrix,
     centered relative to the average, for each feature.
     Therefore, for a given target `t`, this number for feature `f` is larger than 0
     when P(f|t) is greater than the geometric mean of the P(f|t') over all t,
     and smaller otherwise.
     """
-    bias_row: pd.Series[float] = matrix.loc["bias"]  # type: ignore
+    bias_row: pd.Series[float] = np.log2(matrix.loc["bias"])  # type: ignore
     bias_row = bias_row - bias_row.mean()
 
     matrix = matrix.drop(["bias"], axis=0, inplace=False)
-    log_probs: pd.DataFrame = np.log(matrix)  # type: ignore
+    log_probs: pd.DataFrame = np.log2(matrix)  # type: ignore
     log_probs = log_probs.apply(lambda row: row - row.mean(), axis=1)  # type: ignore
     return log_probs, bias_row
 

--- a/app/suggestions2/app/naive_bayes/test_matrix.py
+++ b/app/suggestions2/app/naive_bayes/test_matrix.py
@@ -114,7 +114,7 @@ def test_explanations() -> None:
     matrix.fit(dataset)
 
     s = student_from_indices("s5", [], targets, [0, 1], [2], features)
-    expl, _ = matrix.explain(s.basket, ["fa", "ma"])
+    expl, popularity = matrix.explain(s.basket, ["fa", "ma"])
 
     assert "fa" in expl
     assert "ma" in expl
@@ -122,3 +122,8 @@ def test_explanations() -> None:
     assert expl["fa"][("f1", "positive")] < expl["ma"][("f1", "positive")]
     assert expl["fa"][("m1", "positive")] < expl["ma"][("m1", "positive")]
     assert expl["fa"][("d1", "negative")] > expl["ma"][("d1", "negative")]
+
+    assert "fa" in popularity
+    assert "ma" in popularity
+
+    assert popularity["fa"] < popularity["ma"]


### PR DESCRIPTION
L'explication de Naive Bayes utilise les log-probas (pour des questions de scaling).
L'implémentation actuelle utlisait les probas directement pour la popularité; cette PR corrige ce problème.
Au passage, on utilise le log2 plutôt que le ln (plus facile à interpréter).