### PR TITLE
Suggestions2 : fichier de configuration pour les champs de la BDD et tolérance aux valeurs inconnus dans les champs bac, duree, apprentissage et niveau

### DIFF
--- a/app/suggestions2/README.md
+++ b/app/suggestions2/README.md
@@ -101,3 +101,8 @@ Remplacez `.env` par le nom du fichier contenant les variables d'environnement.
 
 Il faut placer le conteneur de `suggestions2` et celui de la BDD dans un même réseau, et assigner à la variable `DB_SUGGESTIONS2_HOSTNAME` le nom d'hôte de la BDD sur ce réseau.
 Il faut aussi exposer le port 80 de `suggestions2` (potentiellement mappé à un autre port): l'API sera accessible via ce port.
+
+
+### Noms des champs de la base de données
+
+Pour voir ou modifier les noms des tables et champs utilisés dans la base de données, se référer au fichier `app/suggestions2/app/db_schema.py`.

--- a/app/suggestions2/app/adapters/http/request.py
+++ b/app/suggestions2/app/adapters/http/request.py
@@ -1,9 +1,16 @@
 from enum import Enum
 from typing import List, Literal
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from app.config import LOGGER
 from app.domain.models.config import ProfileConfig
 from app.domain.models.profile import Item, Profile
+from app.nomenclatures import (
+    KNOWN_NIVEAU_TYPES,
+    KNOWN_APPRENTISSAGE_TYPES,
+    KNOWN_BAC_TYPES,
+    KNOWN_DUREE_TYPES,
+)
 
 
 class Choix(BaseModel):
@@ -17,41 +24,71 @@ class ChoixStatus(Enum):
     Deleted = 2
 
 
+def _make_nomenclature_validator(
+    known_values: set[str], field_name: str, default: str | None
+):
+    """Crée un validateur qui log un warning si la valeur est inconnue."""
+
+    def validator(v: str | None) -> str | None:
+        if v is None or v in known_values:
+            return v
+        LOGGER.warning(f"{field_name} inconnu: '{v}'. Attendu: {sorted(known_values)}.")
+        return default
+
+    return validator
+
+
+_validate_niveau = _make_nomenclature_validator(KNOWN_NIVEAU_TYPES, "Niveau", "")
+_validate_bac = _make_nomenclature_validator(KNOWN_BAC_TYPES, "Type de bac", None)
+_validate_duree = _make_nomenclature_validator(KNOWN_DUREE_TYPES, "Type de durée", "")
+_validate_apprentissage = _make_nomenclature_validator(
+    KNOWN_APPRENTISSAGE_TYPES, "Type d'apprentissage", ""
+)
+
+
 class SuggestionRequestProfile(BaseModel):
-    niveau: Literal["", "sec", "prem", "term"] = Field(
+    niveau: str = Field(
         default="", description="classe actuelle", examples=["sec", "term"]
     )
-    bac: (
-        Literal[
-            "Générale",
-            "P",
-            "PA",
-            "S2TMD",
-            "ST2S",
-            "STAV",
-            "STD2A",
-            "STHR",
-            "STI2D",
-            "STL",
-            "STMG",
-            "NC",
-        ]
-        | None
-    ) = Field(
+
+    @field_validator("niveau", mode="after")
+    @classmethod
+    def validate_niveau(cls, v: str) -> str:
+        return _validate_niveau(v)
+
+    bac: str | None = Field(
         default=None,
         description="type de Bac choisi ou envisagé",
         examples=["Générale"],
     )
-    duree: Literal["", "court", "long", "indiff"] = Field(
+
+    @field_validator("bac", mode="after")
+    @classmethod
+    def validate_bac(cls, v: str | None) -> str | None:
+        return _validate_bac(v)
+
+    duree: str = Field(
         default="",
         description="durée envisagée des études",
         examples=["court", "long", "indiff"],
     )
-    apprentissage: Literal["", "A", "B", "C", "D"] = Field(
+
+    @field_validator("duree", mode="after")
+    @classmethod
+    def validate_duree(cls, v: str) -> str:
+        return _validate_duree(v)
+
+    apprentissage: str = Field(
         default="",
         description="intérêt pour les formations en apprentissage",
         examples=["A", "B", "C", "D"],
     )
+
+    @field_validator("apprentissage", mode="after")
+    @classmethod
+    def validate_apprentissage(cls, v: str) -> str:
+        return _validate_apprentissage(v)
+
     geo_pref: List[str] = Field(
         [],
         description="villes préférées pour étudier (code insee)",
@@ -67,9 +104,11 @@ class SuggestionRequestProfile(BaseModel):
         description="domaines et intérêts",
         examples=[["ci1", "ci2", "ci3", "dom1", "dom2", "dom3"]],
     )
-    choix: List[Choix] = Field([], description="sélection de formations, voeux et métiers")
-    situation: Literal["aucune_idee", "quelques_pistes", "projet_precis"] | None = Field(
-        default=None, description="statut de réflexion"
+    choix: List[Choix] = Field(
+        [], description="sélection de formations, voeux et métiers"
+    )
+    situation: Literal["aucune_idee", "quelques_pistes", "projet_precis"] | None = (
+        Field(default=None, description="statut de réflexion")
     )
 
     def to_profile(self, config: ProfileConfig):
@@ -97,13 +136,19 @@ class SuggestionRequestProfile(BaseModel):
                 i += [Item(value=v, category=c) for v in l]
 
         metiers_favoris = [
-            f.id for f in self.choix if f.id.startswith("met") and f.status == ChoixStatus.Favorite
+            f.id
+            for f in self.choix
+            if f.id.startswith("met") and f.status == ChoixStatus.Favorite
         ]
         corbeille_formations = [
-            f.id for f in self.choix if f.id.startswith("f") and f.status == ChoixStatus.Deleted
+            f.id
+            for f in self.choix
+            if f.id.startswith("f") and f.status == ChoixStatus.Deleted
         ]
         formations_favorites = [
-            f.id for f in self.choix if f.id.startswith("f") and f.status == ChoixStatus.Favorite
+            f.id
+            for f in self.choix
+            if f.id.startswith("f") and f.status == ChoixStatus.Favorite
         ]
         # voeux_favoris = [
         #     f.id for f in self.choix if f.id.startswith("f") and f.status == ChoixStatus.Favorite
@@ -113,9 +158,14 @@ class SuggestionRequestProfile(BaseModel):
         push_list(config.use_interests, items, self.interests, "interests")
         push_list(config.use_metiers_favoris, items, metiers_favoris, "metiers_favoris")
         push_list(
-            config.use_corbeille_formations, items, corbeille_formations, "corbeille_formations"
+            config.use_corbeille_formations,
+            items,
+            corbeille_formations,
+            "corbeille_formations",
         )
-        push_list(config.use_communes_favorites, items, self.geo_pref, "communes_favorites")
+        push_list(
+            config.use_communes_favorites, items, self.geo_pref, "communes_favorites"
+        )
         push_list(
             config.use_formations_favorites,
             items,
@@ -133,7 +183,9 @@ class SuggestionRequestProfile(BaseModel):
 
 
 class SuggestionRequest(BaseModel):
-    profile: SuggestionRequestProfile = Field(description="Profil utilisé pour évaluer les scores.")
+    profile: SuggestionRequestProfile = Field(
+        description="Profil utilisé pour évaluer les scores."
+    )
     keys: list[str] = Field(
         description="Liste des clés pour lesquelles les suggestions sont demandées.",
         default_factory=list,
@@ -142,7 +194,9 @@ class SuggestionRequest(BaseModel):
 
 
 class ExplanationRequest(BaseModel):
-    profile: SuggestionRequestProfile = Field(description="Profil utilisé pour évaluer les scores.")
+    profile: SuggestionRequestProfile = Field(
+        description="Profil utilisé pour évaluer les scores."
+    )
     keys: list[str] = Field(
         description="Liste des clés pour lesquelles les explications sont demandées.",
         default_factory=list,

--- a/app/suggestions2/app/adapters/pg_database.py
+++ b/app/suggestions2/app/adapters/pg_database.py
@@ -6,9 +6,10 @@ import psycopg as pg
 from dotenv import load_dotenv
 from psycopg.rows import DictRow, class_row, dict_row
 from psycopg.sql import SQL, Identifier
-from pydantic import BaseModel, BeforeValidator
+from pydantic import BaseModel, BeforeValidator, Field
 
 from app.config import LOGGER
+from app.db_schema import DbColumns, JsonNestedFields
 from app.domain.models.config import ProfileConfig
 from app.domain.models.profile import Item, Profile
 from app.domain.ports.data_repository import DataRepository
@@ -69,21 +70,21 @@ def parse_formations(val: List[Dict[str, Any]] | None) -> List[str]:
     """
     Extract the IDs of the formations
     """
-    return [f["idFormation"] for f in val or []]
+    return [f[JsonNestedFields.FORMATION_ID] for f in val or []]
 
 
 def parse_voeux(val: List[Dict[str, Any]] | None) -> List[str]:
     """
     Extract the IDs of the "parcoursup voeux"
     """
-    return [v["idVoeu"] for v in val or []]
+    return [v[JsonNestedFields.VOEU_ID] for v in val or []]
 
 
 def parse_communes(val: List[Dict[str, Any]] | None) -> List[str]:
     """
     Extract the INSEE Code of the cities
     """
-    return [c["codeInsee"] for c in val or []]
+    return [c[JsonNestedFields.COMMUNE_CODE_INSEE] for c in val or []]
 
 
 def none_to_empty_list(val: List[Any] | None) -> List[Any]:
@@ -91,20 +92,36 @@ def none_to_empty_list(val: List[Any] | None) -> List[Any]:
 
 
 class StudentDbRow(BaseModel):
-    id: str
-    situation: str | None
-    classe: str | None
-    id_baccalaureat: str | None
-    duree_etudes_prevue: str | None
-    alternance: str | None
-    specialites: Annotated[List[str], BeforeValidator(none_to_empty_list)] = []
-    domaines: Annotated[List[str], BeforeValidator(none_to_empty_list)] = []
-    centres_interets: Annotated[List[str], BeforeValidator(none_to_empty_list)] = []
-    metiers_favoris: Annotated[List[str], BeforeValidator(none_to_empty_list)] = []
-    corbeille_formations: Annotated[List[str], BeforeValidator(none_to_empty_list)] = []
-    communes_favorites: Annotated[List[str], BeforeValidator(parse_communes)] = []
-    formations_favorites: Annotated[List[str], BeforeValidator(parse_formations)] = []
-    voeux_favoris: Annotated[List[str], BeforeValidator(parse_voeux)] = []
+    id: str = Field(alias=DbColumns.ID)
+    situation: str | None = Field(alias=DbColumns.SITUATION)
+    classe: str | None = Field(alias=DbColumns.CLASSE)
+    id_baccalaureat: str | None = Field(alias=DbColumns.ID_BACCALAUREAT)
+    duree_etudes_prevue: str | None = Field(alias=DbColumns.DUREE_ETUDES_PREVUE)
+    alternance: str | None = Field(alias=DbColumns.ALTERNANCE)
+    specialites: Annotated[List[str], BeforeValidator(none_to_empty_list)] = Field(
+        default=[], alias=DbColumns.SPECIALITES
+    )
+    domaines: Annotated[List[str], BeforeValidator(none_to_empty_list)] = Field(
+        default=[], alias=DbColumns.DOMAINES
+    )
+    centres_interets: Annotated[List[str], BeforeValidator(none_to_empty_list)] = Field(
+        default=[], alias=DbColumns.CENTRES_INTERETS
+    )
+    metiers_favoris: Annotated[List[str], BeforeValidator(none_to_empty_list)] = Field(
+        default=[], alias=DbColumns.METIERS_FAVORIS
+    )
+    corbeille_formations: Annotated[List[str], BeforeValidator(none_to_empty_list)] = (
+        Field(default=[], alias=DbColumns.CORBEILLE_FORMATIONS)
+    )
+    communes_favorites: Annotated[List[str], BeforeValidator(parse_communes)] = Field(
+        default=[], alias=DbColumns.COMMUNES_FAVORITES
+    )
+    formations_favorites: Annotated[List[str], BeforeValidator(parse_formations)] = (
+        Field(default=[], alias=DbColumns.FORMATIONS_FAVORITES)
+    )
+    voeux_favoris: Annotated[List[str], BeforeValidator(parse_voeux)] = Field(
+        default=[], alias=DbColumns.VOEUX_FAVORIS
+    )
 
     def to_profile(self, config: ProfileConfig) -> Profile:
         items: list[Item] = []

--- a/app/suggestions2/app/db_schema.py
+++ b/app/suggestions2/app/db_schema.py
@@ -1,0 +1,48 @@
+"""
+Configuration des noms de tables, colonnes, et champs JSON pour la base de données.
+"""
+
+
+class DbTables:
+    """Noms par défaut des tables de profils de référence."""
+
+    REF_EXPERT = "profil_reference_expert"
+    REF_LYCEEN = "profil_reference_lyceen"
+
+
+class DbColumns:
+    """Noms des colonnes dans la table des profils étudiants."""
+
+    ID = "id"
+    SITUATION = "situation"
+    CLASSE = "classe"
+    ID_BACCALAUREAT = "id_baccalaureat"
+    DUREE_ETUDES_PREVUE = "duree_etudes_prevue"
+    ALTERNANCE = "alternance"
+    SPECIALITES = "specialites"
+    DOMAINES = "domaines"
+    CENTRES_INTERETS = "centres_interets"
+    METIERS_FAVORIS = "metiers_favoris"
+    CORBEILLE_FORMATIONS = "corbeille_formations"
+    COMMUNES_FAVORITES = "communes_favorites"
+    FORMATIONS_FAVORITES = "formations_favorites"
+    VOEUX_FAVORIS = "voeux_favoris"
+
+
+class JsonNestedFields:
+    """
+    Noms des champs à extraire des objets JSON stockés dans certaines colonnes.
+
+    Certaines colonnes (formations_favorites, communes_favorites, voeux_favoris)
+    contiennent des tableaux d'objets JSON. Ces constantes définissent les noms
+    des champs à extraire de chaque objet lors du parsing.
+
+    Exemples:
+    - formations_favorites: [{"idFormation": "fl210", ...}, ...]
+    - communes_favorites: [{"codeInsee": "33514", ...}, ...]
+    - voeux_favoris: [{"idVoeu": "v123", ...}, ...]
+    """
+
+    FORMATION_ID = "idFormation"
+    VOEU_ID = "idVoeu"
+    COMMUNE_CODE_INSEE = "codeInsee"

--- a/app/suggestions2/app/nomenclatures.py
+++ b/app/suggestions2/app/nomenclatures.py
@@ -1,0 +1,40 @@
+"""
+Nomenclatures des valeurs connues pour les champs de profil.
+"""
+
+KNOWN_NIVEAU_TYPES: set[str] = {
+    "",
+    "sec",
+    "prem",
+    "term",
+}
+
+KNOWN_BAC_TYPES: set[str] = {
+    "Générale",
+    "P",
+    "PA",
+    "S2TMD",
+    "ST2S",
+    "STAV",
+    "STD2A",
+    "STHR",
+    "STI2D",
+    "STL",
+    "STMG",
+    "NC",
+}
+
+KNOWN_DUREE_TYPES: set[str] = {
+    "",
+    "court",
+    "long",
+    "indiff",
+}
+
+KNOWN_APPRENTISSAGE_TYPES: set[str] = {
+    "",
+    "A",
+    "B",
+    "C",
+    "D",
+}

--- a/app/suggestions2/app/setup_fastapi.py
+++ b/app/suggestions2/app/setup_fastapi.py
@@ -8,14 +8,15 @@ from app.adapters.naive_bayes import NaiveBayesMatrix
 from app.adapters.pg_database import PostgresDatabase
 from app.application.service import MultiSuggestionsService
 from app.config import CONFIG, VERSION, LOGGER
+from app.db_schema import DbTables
 
 
 load_dotenv()
 DB_SUGGESTIONS2_REF_EXPERT: str = getenv(
-    "DB_SUGGESTIONS2_REF_EXPERT", default="profil_reference_expert"
+    "DB_SUGGESTIONS2_REF_EXPERT", default=DbTables.REF_EXPERT
 )
 DB_SUGGESTIONS2_REF_LYCEEN: str = getenv(
-    "DB_SUGGESTIONS2_REF_LYCEEN", default="profil_reference_lyceen"
+    "DB_SUGGESTIONS2_REF_LYCEEN", default=DbTables.REF_LYCEEN
 )
 
 app = FastAPI(title="MonProjetSup Suggestions2 API", version=VERSION)


### PR DESCRIPTION
Pull request liée à l’issue #963. ( https://github.com/betagouv/monprojetsup/issues/963 )
ainsi qu'au problème de rigidité face à la nomenclature (cf second commentaire)

Cette PR 
- déplace les noms de tables et de champs utilisés par suggestions2 dans le fichier db_schema.py, afin de faciliter leur modification en cas d’évolution du schéma de la BDD.
- centralise les valeurs connues des champs bac, duree, apprentissage et niveau, dans le fichier nomenclatures.py, et et autorise les requêtes vers suggestions2 avec des valeurs absentes de la nomenclature (dans ce cas, le champ n'est pas pris en compte pour les suggestions et un warning est émis).