### PR TITLE
Suggestions2 : correction d'un bug et ajout d'un score basé sur les données Parcoursup

### DIFF
--- a/app/suggestions2/.env.example
+++ b/app/suggestions2/.env.example
@@ -4,5 +4,8 @@ DB_SUGGESTIONS2_USERNAME=mps_user
 DB_SUGGESTIONS2_PASSWORD=password
 DB_SUGGESTIONS2_HOSTNAME=localhost
 
-DB_SUGGESTIONS2_REF_EXPERT=profil_reference
-DB_SUGGESTIONS2_REF_LYCEEN=profil_eleve
+# optional overrides for table names
+DB_SUGGESTIONS2_REF_EXPERT=profil_reference_expert
+DB_SUGGESTIONS2_REF_LYCEEN=profil_reference_lyceen
+DB_SUGGESTIONS2_PANIERS_VOEUX=sugg_paniers_voeux
+DB_SUGGESTIONS2_JOIN_FORMATION_VOEU=ref_join_formation_voeu

--- a/app/suggestions2/README.md
+++ b/app/suggestions2/README.md
@@ -19,8 +19,10 @@ Récapitulatif des variables d'environnement:
 |`DB_SUGGESTIONS2_USERNAME`| Nom d'utilisateur pour accéder à la BDD | :x: Non |
 |`DB_SUGGESTIONS2_PASSWORD`| Mot de passe pour accéder à la BDD | :x: Non |
 |`DB_SUGGESTIONS2_HOSTNAME`| Nom de l'hôte de la base de données | :white_check_mark: Oui, défault: `localhost`|
-|`DB_SUGGESTIONS2_REF_EXPERT`| Nom de la table contenant les données de référence experts | :white_check_mark: Oui, défault: `profil_reference`|
-|`DB_SUGGESTIONS2_REF_LYCEEN`| Nom de la table contenant les données de référence lycéens | :white_check_mark: Oui, défault: `profil_eleve`|
+|`DB_SUGGESTIONS2_REF_EXPERT`| Nom de la table contenant les données de référence experts | :white_check_mark: Oui, défault: `profil_reference_expert`|
+|`DB_SUGGESTIONS2_REF_LYCEEN`| Nom de la table contenant les données de référence lycéens | :white_check_mark: Oui, défault: `profil_reference_lyceen`|
+|`DB_SUGGESTIONS2_PANIERS_VOEUX`| Nom de la table contenant les paniers de vœux | :white_check_mark: Oui, défault: `sugg_paniers_voeux`|
+|`DB_SUGGESTIONS2_JOIN_FORMATION_VOEU`| Nom de la table de jointure formation-vœu | :white_check_mark: Oui, défault: `ref_join_formation_voeu`|
 
 
 ### Lancer l'application manuellement
@@ -105,4 +107,4 @@ Il faut aussi exposer le port 80 de `suggestions2` (potentiellement mappé à un
 
 ### Noms des champs de la base de données
 
-Pour voir ou modifier les noms des tables et champs utilisés dans la base de données, se référer au fichier `app/suggestions2/app/db_schema.py`.
+Pour voir ou modifier les noms des tables et champs utilisés dans la base de données par défaut, se référer au fichier `app/suggestions2/app/db_schema.py`.

--- a/app/suggestions2/README.md
+++ b/app/suggestions2/README.md
@@ -1,5 +1,34 @@
 # ML Suggestions2 Endpoint
 
+## Fonctionnement
+
+### Scores de suggestions
+
+Suggestions2 calcule et renvoie trois scores pour chaque formation :
+
+| Score | Source de données par défaut dans la DB | Description |
+|:------|:------------------|:------------|
+| **expert** | `profil_reference_expert` | Basé sur les profils de référence créés par les experts métier |
+| **lyceen** | `profil_reference_lyceen` | Basé sur les profils des lycéens utilisant MonProjetSup |
+| **parcoursup** | `sugg_paniers_voeux` | Basé sur les paniers de vœux Parcoursup |
+
+#### Détails de fonctionnement du score Parcoursup
+
+Ce score exploite les paniers de vœux issus des données Parcoursup.
+
+Le principe est d'apprendre quelles formations sont fréquemment choisies ensemble par les candidats Parcoursup. Si un utilisateur s'intéresse à certaines formations, ce score suggère les formations qui étaient souvent présentes dans les mêmes paniers de vœux.
+
+Il fonctionne de la manière suivante :
+
+1. **Chargement des paniers de vœux** : La table `sugg_paniers_voeux` contient les vœux (du type `taXXX`) de candidats Parcoursup, regroupés par panier (un panier = les vœux d'un candidat).
+
+2. **Conversion vœux -> formations** : Les vœux Parcoursup (`taXXX`) correspondent à des formations spécifiques dans des établissements précis. La table de jointure `ref_join_formation_voeu` permet de convertir ces vœux en formations génériques (`flXXX`) utilisées par MonProjetSup.
+
+3. **Apprentissage des co-occurrences** : Chaque panier est ensuite traité comme un "profil" contenant un ensemble de formations favorites. A partir des ces profils, le modèle Naive Bayes (cf. la classe `NaiveBayesMatrix` du fichier `naive_bayes.py`) construit une matrice contenant les probabilités qu'une formation soit choisie sachant qu'une autre formation est présente dans le panier.
+
+4. **Calcul du score** : Pour un utilisateur donné, le score `parcoursup`d'une formation est alors calculé en fonction de toutes les formations qu'il a déjà marquées comme favorites, et de la matrice précédemment construite. Plus une formation apparaît fréquemment avec les formations favorites de l'utilisateur, plus son score sera élevé.
+
+
 ## Comment lancer le endpoint suggestions2
 
 ### Paramétrer l'accès à la base de données

--- a/app/suggestions2/app/adapters/http/request.py
+++ b/app/suggestions2/app/adapters/http/request.py
@@ -138,17 +138,17 @@ class SuggestionRequestProfile(BaseModel):
         metiers_favoris = [
             f.id
             for f in self.choix
-            if f.id.startswith("met") and f.status == ChoixStatus.Favorite
+            if f.id.startswith("met") and f.status == ChoixStatus.Favorite.value
         ]
         corbeille_formations = [
             f.id
             for f in self.choix
-            if f.id.startswith("f") and f.status == ChoixStatus.Deleted
+            if f.id.startswith("f") and f.status == ChoixStatus.Deleted.value
         ]
         formations_favorites = [
             f.id
             for f in self.choix
-            if f.id.startswith("f") and f.status == ChoixStatus.Favorite
+            if f.id.startswith("f") and f.status == ChoixStatus.Favorite.value
         ]
         # voeux_favoris = [
         #     f.id for f in self.choix if f.id.startswith("f") and f.status == ChoixStatus.Favorite

--- a/app/suggestions2/app/adapters/pg_database.py
+++ b/app/suggestions2/app/adapters/pg_database.py
@@ -1,4 +1,5 @@
 import os
+from collections import defaultdict
 from typing import Annotated, Any, Dict, List, Literal
 from urllib.parse import quote_plus
 
@@ -9,7 +10,7 @@ from psycopg.sql import SQL, Identifier
 from pydantic import BaseModel, BeforeValidator, Field
 
 from app.config import LOGGER
-from app.db_schema import DbColumns, JsonNestedFields
+from app.db_schema import DbColumns, DbTables, JsonNestedFields
 from app.domain.models.config import ProfileConfig
 from app.domain.models.profile import Item, Profile
 from app.domain.ports.data_repository import DataRepository
@@ -56,6 +57,71 @@ class PostgresDatabase(DataRepository):
             cursor.execute(query)
             students_data = cursor.fetchall()
         return [s.to_profile(config) for s in students_data]
+
+    def load_paniers_voeux_as_profiles(
+        self,
+        paniers_table: str = DbTables.PANIERS_VOEUX,
+        join_table: str = DbTables.JOIN_FORMATION_VOEU,
+    ) -> list[Profile]:
+        """
+        Loads wish baskets "parcoursup" and converts them to Profiles for NaiveBayesMatrix.
+
+        paniers_table contains list of taXXX wishes that map to list of flXXX formations via join_table.
+
+        Each basket becomes a Profile where:
+        - features = the formations of the basket, category "formations_favorites"
+        - targets = the same formations
+
+        Returns:
+            List of Profiles representing formation co-occurrences
+        """
+        LOGGER.info(f"Loading voeu to formations mapping from '{join_table}'...")
+        query_mapping = SQL("SELECT id_formation, id_voeu FROM {}").format(
+            Identifier(join_table)
+        )
+        with self.connection.cursor() as cursor:
+            cursor.execute(query_mapping)
+            rows = cursor.fetchall()
+
+        # TODO: vérifier s'il est possible d'avoir plusieurs formations par voeu
+        # si ce n'est pas le cas on peut simplifier et utiliser Dict[str, str] au lieu de Dict[str, List[str]]
+        voeu_to_formations: Dict[str, List[str]] = defaultdict(list)
+        for row in rows:
+            voeu_to_formations[row["id_voeu"]].append(row["id_formation"])
+        LOGGER.info(f"Loaded mapping for {len(voeu_to_formations)} voeux.")
+
+        LOGGER.info(f"Loading paniers de voeux from '{paniers_table}'...")
+        query_paniers = SQL("SELECT id, bac, voeux FROM {}").format(
+            Identifier(paniers_table)
+        )
+        with self.connection.cursor() as cursor:
+            cursor.execute(query_paniers)
+            paniers_rows = cursor.fetchall()
+
+        profiles: list[Profile] = []
+        for row in paniers_rows:
+            voeux = row["voeux"] if row["voeux"] else []
+            formations_set: set[str] = set()
+            for voeu in voeux:
+                if voeu in voeu_to_formations:
+                    formations_set.update(voeu_to_formations[voeu])
+
+            if formations_set:
+                formations = list(formations_set)
+                profile = Profile(
+                    features=[
+                        Item(value=fl, category="formations_favorites")
+                        for fl in formations
+                    ],
+                    targets=formations,
+                )
+                profiles.append(profile)
+
+        LOGGER.info(
+            f"Converted {len(profiles)} paniers to profiles "
+            f"(from {len(paniers_rows)} total paniers)."
+        )
+        return profiles
 
 
 def get_env_or_raise(var_name: str) -> str:

--- a/app/suggestions2/app/db_schema.py
+++ b/app/suggestions2/app/db_schema.py
@@ -1,5 +1,6 @@
 """
-Configuration des noms de tables, colonnes, et champs JSON pour la base de données.
+Configuration des noms par défaut de tables, colonnes, et champs JSON pour la base de données.
+REF_EXPERT, REF_LYCEEN, PANIERS_VOEUX, JOIN_FORMATION_VOEU peuvent être surchargés via des variables d'environnement (dans le .env).
 """
 
 
@@ -8,6 +9,8 @@ class DbTables:
 
     REF_EXPERT = "profil_reference_expert"
     REF_LYCEEN = "profil_reference_lyceen"
+    PANIERS_VOEUX = "sugg_paniers_voeux"
+    JOIN_FORMATION_VOEU = "ref_join_formation_voeu"
 
 
 class DbColumns:

--- a/app/suggestions2/app/setup_fastapi.py
+++ b/app/suggestions2/app/setup_fastapi.py
@@ -18,6 +18,12 @@ DB_SUGGESTIONS2_REF_EXPERT: str = getenv(
 DB_SUGGESTIONS2_REF_LYCEEN: str = getenv(
     "DB_SUGGESTIONS2_REF_LYCEEN", default=DbTables.REF_LYCEEN
 )
+DB_SUGGESTIONS2_PANIERS_VOEUX: str = getenv(
+    "DB_SUGGESTIONS2_PANIERS_VOEUX", default=DbTables.PANIERS_VOEUX
+)
+DB_SUGGESTIONS2_JOIN_FORMATION_VOEU: str = getenv(
+    "DB_SUGGESTIONS2_JOIN_FORMATION_VOEU", default=DbTables.JOIN_FORMATION_VOEU
+)
 
 app = FastAPI(title="MonProjetSup Suggestions2 API", version=VERSION)
 
@@ -46,12 +52,25 @@ data_profil_lyceen = data_repo.load_profiles(
 )
 profil_lyceen_service = NaiveBayesMatrix(regularization_laplace=1.0)
 profil_lyceen_service.init_from_profiles(data_profil_lyceen)
-# TODO: add other services here.
+
+LOGGER.info(
+    f"Creating 'voeux_parcoursup' service based on tables "
+    f"${DB_SUGGESTIONS2_PANIERS_VOEUX} and ${DB_SUGGESTIONS2_JOIN_FORMATION_VOEU}..."
+)
+data_voeux_parcoursup = data_repo.load_paniers_voeux_as_profiles(
+    paniers_table=DB_SUGGESTIONS2_PANIERS_VOEUX,
+    join_table=DB_SUGGESTIONS2_JOIN_FORMATION_VOEU,
+)
+voeux_parcoursup_service = NaiveBayesMatrix(regularization_laplace=1.0)
+voeux_parcoursup_service.init_from_profiles(data_voeux_parcoursup)
+
+# TODO: add more services here
 
 LOGGER.info("Creating aggregate service...")
 service = MultiSuggestionsService(
     expert=profil_expert_service,
     lyceen=profil_lyceen_service,
+    parcoursup=voeux_parcoursup_service,
 )
 
 LOGGER.info("Creating endpoint...")


### PR DESCRIPTION
### TL;DR
Cette PR :
- Corrige un bug dans `suggestions2` qui empêchait la prise en compte de certaines préférences utilisateur
- Ajoute un nouveau score basé sur les paniers de voeux Parcoursup (cf. issue https://github.com/betagouv/monprojetsup/issues/843)

---

### Détails du bug

Dans `request.py`, le champ `f.status` est un `int`, mais il était comparé directement aux membres de l'enum `ChoixStatus` (ex : `f.status == ChoixStatus.Favorite`), ce qui retourne toujours `False` en python.

Par conséquent, les préférences utilisateur suivantes n’étaient jamais prises en compte dans le calcul des scores : `metiers_favoris`, `corbeille_formations` et `formations_favorites`

La correction consiste à comparer `f.status` à `ChoixStatus.Favorite.value`.

---

 ### Nouveau score basé sur les données Parcoursup

Ce nouveau score exploite les paniers de vœux issus des données Parcoursup.

Il fonctionne de la manière suivante :
- Chargement des paniers de vœux (`sugg_paniers_voeux`) contenant les choix (du type `taXXX`)
- Conversion des vœux en formations (`flXXX`) via la table de jointure `ref_join_formation_voeu` (taXXX -> flXXX)
- Chaque panier est alors traité comme un profil utilisateur contenant une liste de formations favorites, ce qui permet de créer la matrice Naive Bayes relative à ces profils (~co-occurences des formations au sein des paniers)
- Le calcul du score est alors similaire aux scores  `expert` et `lyceen`, mais utilise la matrice précédemment construite.

Suggestions2 renvoie désormais trois scores :
- `expert` : basé sur les profils de référence créés par les experts métier
- `lyceen` : basé sur les profils des lycéens utilisant MonProjetSup
- `parcoursup` : basé sur les paniers de vœux Parcoursup
