### PR TITLE
refactor(suggestions2): reduce memory usage

### DIFF
--- a/app/suggestions2/app/adapters/naive_bayes.py
+++ b/app/suggestions2/app/adapters/naive_bayes.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, Iterator, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -20,8 +20,10 @@ class NaiveBayesMatrix(ExplainableSuggestionsEngine):
         self.explanation_popularity: pd.Series = pd.Series()
         self.regularization_laplace = regularization_laplace
 
-    def init_from_profiles(self, profiles: list[Profile]):
-        self.matrix = compute_naive_bayes_matrix(profiles, self.regularization_laplace)
+    def init_from_profiles_batched(self, profiles_iterator: Iterator[list[Profile]]):
+        self.matrix = compute_naive_bayes_matrix_batched(
+            profiles_iterator, self.regularization_laplace
+        )
         self.explanation_matrix, self.explanation_popularity = (
             compute_explanation_matrix(self.matrix)
         )
@@ -41,8 +43,8 @@ class NaiveBayesMatrix(ExplainableSuggestionsEngine):
         return str(self.matrix)
 
 
-def compute_naive_bayes_matrix(
-    profiles: list[Profile],
+def compute_naive_bayes_matrix_batched(
+    profiles_iterator: Iterator[list[Profile]],
     regularization_laplace: float,
 ) -> pd.DataFrame:
     """
@@ -52,21 +54,44 @@ def compute_naive_bayes_matrix(
 
     `regularization_laplace`: Parameter alpha for regularization,
     see [https://scikit-learn.org/stable/modules/naive_bayes.html#categorical-naive-bayes](here).
+
+    This function processes the profiles in batches to reduce memory usage (needed).
     """
     co_occurences_target_key: Dict[Tuple[str, str], int] = defaultdict(int)
     occurences_target: Dict[str, int] = defaultdict(int)
-    n_profiles: int = len(profiles)
+    n_profiles: int = 0
     all_key_values: set[str] = set()
 
-    # Count occurrences and co-occurrences
-    for profile in profiles:
-        for t in profile.targets:
-            occurences_target[t] += 1
+    # Count occurrences and co-occurrences incrementally
+    for batch in profiles_iterator:
+        for profile in batch:
+            n_profiles += 1
+            for t in profile.targets:
+                occurences_target[t] += 1
 
-            for v in profile.features_str():
-                all_key_values.add(v)
-                co_occurences_target_key[(t, v)] += 1
+                for v in profile.features_str():
+                    all_key_values.add(v)
+                    co_occurences_target_key[(t, v)] += 1
 
+    return _build_bayes_dataframe(
+        co_occurences_target_key,
+        occurences_target,
+        all_key_values,
+        n_profiles,
+        regularization_laplace,
+    )
+
+
+def _build_bayes_dataframe(
+    co_occurences_target_key: Dict[Tuple[str, str], int],
+    occurences_target: Dict[str, int],
+    all_key_values: set[str],
+    n_profiles: int,
+    regularization_laplace: float,
+) -> pd.DataFrame:
+    """
+    Builds the Naive Bayes DataFrame from the counters.
+    """
     # Compute the conditional probabilities P(t | v)
     dict_bayes: Dict[str, Dict[str, float]] = defaultdict(lambda: defaultdict(float))
     for t, count_t in occurences_target.items():

--- a/app/suggestions2/app/adapters/pg_database.py
+++ b/app/suggestions2/app/adapters/pg_database.py
@@ -1,6 +1,6 @@
 import os
 from collections import defaultdict
-from typing import Annotated, Any, Dict, List, Literal
+from typing import Annotated, Any, Dict, Iterator, List, Literal
 from urllib.parse import quote_plus
 
 import psycopg as pg
@@ -51,20 +51,44 @@ class PostgresDatabase(DataRepository):
             password=DB_PASSWORD,
         )
 
-    def load_profiles(self, table_name: str, config: ProfileConfig) -> list[Profile]:
+    def iter_profiles_batched(
+        self,
+        table_name: str,
+        config: ProfileConfig,
+        batch_size: int = 10000,
+    ) -> Iterator[list[Profile]]:
+        """
+        Iterator that loads profiles from the given table in batches.
+        """
+        LOGGER.info(f"Loading profiles from '{table_name}' (batched)...")
         query = SQL("SELECT * FROM {}").format(Identifier(table_name))
-        with self.connection.cursor(row_factory=class_row(StudentDbRow)) as cursor:
-            cursor.execute(query)
-            students_data = cursor.fetchall()
-        return [s.to_profile(config) for s in students_data]
 
-    def load_paniers_voeux_as_profiles(
+        # NOTE: 'name=server_cursor_profiles' is needed to create a server-side cursor (by default it is client-side)
+        with self.connection.cursor(
+            name="server_cursor_profiles", row_factory=class_row(StudentDbRow)
+        ) as cursor:
+            cursor.execute(query)
+            total = 0
+
+            while True:
+                students_data = cursor.fetchmany(batch_size)
+                if not students_data:
+                    break
+
+                profiles = [s.to_profile(config) for s in students_data]
+                total += len(profiles)
+                yield profiles
+
+        LOGGER.info(f"Loaded {total} profiles from '{table_name}'.")
+
+    def iter_paniers_voeux_as_profiles_batched(
         self,
         paniers_table: str = DbTables.PANIERS_VOEUX,
         join_table: str = DbTables.JOIN_FORMATION_VOEU,
-    ) -> list[Profile]:
+        batch_size: int = 10000,
+    ) -> Iterator[list[Profile]]:
         """
-        Loads wish baskets "parcoursup" and converts them to Profiles for NaiveBayesMatrix.
+        Iterator that load, in batches, wish baskets "parcoursup" and converts them to Profiles for NaiveBayesMatrix.
 
         paniers_table contains list of taXXX wishes that map to list of flXXX formations via join_table.
 
@@ -75,33 +99,62 @@ class PostgresDatabase(DataRepository):
         Returns:
             List of Profiles representing formation co-occurrences
         """
+        voeu_to_formations = self._load_voeu_to_formations_mapping(join_table)
+
+        LOGGER.info(f"Loading paniers de voeux from '{paniers_table}' (batched)...")
+        query_paniers = SQL("SELECT id, bac, voeux FROM {}").format(
+            Identifier(paniers_table)
+        )
+
+        with self.connection.cursor(name="server_cursor_paniers") as cursor:
+            cursor.execute(query_paniers)
+            total = 0
+
+            while True:
+                paniers = cursor.fetchmany(batch_size)
+                if not paniers:
+                    break
+
+                profiles = self._convert_paniers_to_profiles(paniers, voeu_to_formations)
+                total += len(profiles)
+                if profiles:
+                    yield profiles
+
+        LOGGER.info(f"Loaded {total} profiles from paniers de voeux.")
+
+    def _load_voeu_to_formations_mapping(
+        self, join_table: str
+    ) -> Dict[str, List[str]]:
+        """Load the mapping voeu -> formations."""
         LOGGER.info(f"Loading voeu to formations mapping from '{join_table}'...")
         query_mapping = SQL("SELECT id_formation, id_voeu FROM {}").format(
             Identifier(join_table)
         )
-        with self.connection.cursor() as cursor:
-            cursor.execute(query_mapping)
-            rows = cursor.fetchall()
-
+        
         # TODO: vérifier s'il est possible d'avoir plusieurs formations par voeu
         # si ce n'est pas le cas on peut simplifier et utiliser Dict[str, str] au lieu de Dict[str, List[str]]
         voeu_to_formations: Dict[str, List[str]] = defaultdict(list)
-        for row in rows:
-            voeu_to_formations[row["id_voeu"]].append(row["id_formation"])
-        LOGGER.info(f"Loaded mapping for {len(voeu_to_formations)} voeux.")
-
-        LOGGER.info(f"Loading paniers de voeux from '{paniers_table}'...")
-        query_paniers = SQL("SELECT id, bac, voeux FROM {}").format(
-            Identifier(paniers_table)
-        )
         with self.connection.cursor() as cursor:
-            cursor.execute(query_paniers)
-            paniers_rows = cursor.fetchall()
+            cursor.execute(query_mapping)
+            rows = cursor.fetchall()
+            for row in rows:
+                voeu_to_formations[row["id_voeu"]].append(row["id_formation"])
+        
+        LOGGER.info(f"Loaded mapping for {len(voeu_to_formations)} voeux.")
+        return voeu_to_formations
 
+    def _convert_paniers_to_profiles(
+        self,
+        paniers_rows: list,
+        voeu_to_formations: Dict[str, List[str]],
+    ) -> list[Profile]:
+        """Converts wish baskets rows to Profiles."""
         profiles: list[Profile] = []
+        
         for row in paniers_rows:
             voeux = row["voeux"] if row["voeux"] else []
             formations_set: set[str] = set()
+            
             for voeu in voeux:
                 if voeu in voeu_to_formations:
                     formations_set.update(voeu_to_formations[voeu])
@@ -117,10 +170,6 @@ class PostgresDatabase(DataRepository):
                 )
                 profiles.append(profile)
 
-        LOGGER.info(
-            f"Converted {len(profiles)} paniers to profiles "
-            f"(from {len(paniers_rows)} total paniers)."
-        )
         return profiles
 
 

--- a/app/suggestions2/app/adapters/test_naive_bayes.py
+++ b/app/suggestions2/app/adapters/test_naive_bayes.py
@@ -22,7 +22,7 @@ def test_naive_bayes():
         regularization_laplace=1.0,
     )
 
-    matrix.init_from_profiles(profiles)
+    matrix.init_from_profiles_batched(iter([profiles]))
 
     res = matrix.suggest(
         Profile(
@@ -62,7 +62,7 @@ def test_explanation():
         regularization_laplace=1.0,
     )
 
-    matrix.init_from_profiles(profiles)
+    matrix.init_from_profiles_batched(iter([profiles]))
 
     res = matrix.explain(
         Profile(

--- a/app/suggestions2/app/domain/ports/data_repository.py
+++ b/app/suggestions2/app/domain/ports/data_repository.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-
+from typing import Iterator
 
 from app.domain.models.config import ProfileConfig
 from app.domain.models.profile import Profile
@@ -7,5 +7,7 @@ from app.domain.models.profile import Profile
 
 class DataRepository(ABC):
     @abstractmethod
-    def load_profiles(self, table_name: str, config: ProfileConfig) -> list[Profile]:
-        raise NotImplementedError("Method 'load_profiles' not implemented")
+    def iter_profiles_batched(
+        self, table_name: str, config: ProfileConfig, batch_size: int = 10000
+    ) -> Iterator[list[Profile]]:
+        raise NotImplementedError("Method 'iter_profiles_batched' not implemented")

--- a/app/suggestions2/app/domain/ports/suggestion.py
+++ b/app/suggestions2/app/domain/ports/suggestion.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-
+from typing import Iterator
 
 from app.domain.models.explanation import Explanations
 from app.domain.models.profile import Profile
@@ -8,8 +8,8 @@ from app.domain.models.suggestion import Suggestions
 
 class ExplainableSuggestionsEngine(ABC):
     @abstractmethod
-    def init_from_profiles(self, profiles: list[Profile]):
-        raise NotImplementedError("Method 'init_from_profiles' not implemented")
+    def init_from_profiles_batched(self, profiles_iterator: Iterator[list[Profile]]):
+        raise NotImplementedError("Method 'init_from_profiles_batched' not implemented")
 
     @abstractmethod
     def suggest(self, profile: Profile) -> Suggestions:

--- a/app/suggestions2/app/setup_fastapi.py
+++ b/app/suggestions2/app/setup_fastapi.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from prometheus_client import make_asgi_app
 from os import getenv
 from dotenv import load_dotenv
+from typing import Iterator
 
 from app.adapters.http.make_endpoint import make_endpoint
 from app.adapters.naive_bayes import NaiveBayesMatrix
@@ -9,6 +10,7 @@ from app.adapters.pg_database import PostgresDatabase
 from app.application.service import MultiSuggestionsService
 from app.config import CONFIG, VERSION, LOGGER
 from app.db_schema import DbTables
+from app.domain.models.profile import Profile
 
 
 load_dotenv()
@@ -32,46 +34,61 @@ metrics_app = make_asgi_app()
 app.mount("/metrics", metrics_app)
 
 
-LOGGER.info("Creating DB connection...")
-data_repo = PostgresDatabase.from_env()
+def create_naive_bayes_service(
+    name: str,
+    profiles_iterator: Iterator[list[Profile]],
+    regularization_laplace: float = 1.0,
+) -> NaiveBayesMatrix:
+    """
+    Create a NaiveBayes service from a batched profiles iterator.
+    """
+    LOGGER.info(f"Creating '{name}' service...")
+    service = NaiveBayesMatrix(regularization_laplace=regularization_laplace)
+    service.init_from_profiles_batched(profiles_iterator)
+    LOGGER.info(f"Service '{name}' created with matrix shape {service.matrix.shape}")
+    return service
 
-LOGGER.info(
-    f"Creating 'profil_expert' service based on ref table ${DB_SUGGESTIONS2_REF_EXPERT}..."
-)
-data_profil_eleve = data_repo.load_profiles(
-    table_name=DB_SUGGESTIONS2_REF_EXPERT, config=CONFIG
-)
-profil_expert_service = NaiveBayesMatrix(regularization_laplace=1.0)
-profil_expert_service.init_from_profiles(data_profil_eleve)
 
-LOGGER.info(
-    f"Creating 'profil_eleve' service service based on ref table ${DB_SUGGESTIONS2_REF_LYCEEN}..."
-)
-data_profil_lyceen = data_repo.load_profiles(
-    table_name=DB_SUGGESTIONS2_REF_LYCEEN, config=CONFIG
-)
-profil_lyceen_service = NaiveBayesMatrix(regularization_laplace=1.0)
-profil_lyceen_service.init_from_profiles(data_profil_lyceen)
+def create_services() -> MultiSuggestionsService:
+    """
+    Create the different services for suggestions2.
+    """
+    LOGGER.info("Creating DB connection...")
+    data_repo = PostgresDatabase.from_env()
 
-LOGGER.info(
-    f"Creating 'voeux_parcoursup' service based on tables "
-    f"${DB_SUGGESTIONS2_PANIERS_VOEUX} and ${DB_SUGGESTIONS2_JOIN_FORMATION_VOEU}..."
-)
-data_voeux_parcoursup = data_repo.load_paniers_voeux_as_profiles(
-    paniers_table=DB_SUGGESTIONS2_PANIERS_VOEUX,
-    join_table=DB_SUGGESTIONS2_JOIN_FORMATION_VOEU,
-)
-voeux_parcoursup_service = NaiveBayesMatrix(regularization_laplace=1.0)
-voeux_parcoursup_service.init_from_profiles(data_voeux_parcoursup)
+    profil_expert_service = create_naive_bayes_service(
+        name="profil_expert",
+        profiles_iterator=data_repo.iter_profiles_batched(
+            table_name=DB_SUGGESTIONS2_REF_EXPERT,
+            config=CONFIG,
+        ),
+    )
 
+    profil_lyceen_service = create_naive_bayes_service(
+        name="profil_lyceen",
+        profiles_iterator=data_repo.iter_profiles_batched(
+            table_name=DB_SUGGESTIONS2_REF_LYCEEN,
+            config=CONFIG,
+        ),
+    )
+
+    voeux_parcoursup_service = create_naive_bayes_service(
+        name="voeux_parcoursup",
+        profiles_iterator=data_repo.iter_paniers_voeux_as_profiles_batched(
+            paniers_table=DB_SUGGESTIONS2_PANIERS_VOEUX,
+            join_table=DB_SUGGESTIONS2_JOIN_FORMATION_VOEU,
+        ),
+    )
 # TODO: add more services here
+    LOGGER.info("Creating aggregate service...")
+    return MultiSuggestionsService(
+        expert=profil_expert_service,
+        lyceen=profil_lyceen_service,
+        parcoursup=voeux_parcoursup_service,
+    )
 
-LOGGER.info("Creating aggregate service...")
-service = MultiSuggestionsService(
-    expert=profil_expert_service,
-    lyceen=profil_lyceen_service,
-    parcoursup=voeux_parcoursup_service,
-)
+
+service = create_services()
 
 LOGGER.info("Creating endpoint...")
 make_endpoint(service, app, CONFIG)


### PR DESCRIPTION
⚠️ WARNING : ne pas mettre en prod tout de suite, faire des tests d'intégration sur demo d'abord.

Le but de cette PR est de régler le problème de mémoire mentionné dans cette issue https://github.com/betagouv/monprojetsup/issues/1039 

La PR :  
- supprime les variables non utilisées après l'initialisation des différents services de suggestions2
- utilise du batch processing pour construire les matrices Naive Bayes (nécessaire quand le dataset devient grand).

Les tests en local montrent une réduction de ~80% lors de l'utilisation des trois scores.
